### PR TITLE
Test: Inject correct ref for testing feature branches

### DIFF
--- a/slices/brotli.yaml
+++ b/slices/brotli.yaml
@@ -1,0 +1,17 @@
+package: brotli
+
+essential:
+  - brotli_copyright
+
+slices:
+  bins:
+    essential:
+      - libbrotli1_libs
+      - libc6_libs
+    contents:
+      /usr/bin/brotli:
+
+  copyright:
+    contents:
+      /usr/share/doc/brotli/copyright:
+

--- a/slices/libbrotli1.yaml
+++ b/slices/libbrotli1.yaml
@@ -11,7 +11,6 @@ slices:
       /usr/lib/*-linux-*/libbrotlicommon.so.1*:
       /usr/lib/*-linux-*/libbrotlidec.so.1*:
       /usr/lib/*-linux-*/libbrotlienc.so.1*:
-
   copyright:
     contents:
       /usr/share/doc/libbrotli1/copyright:

--- a/tests/spread/integration/brotli/task.yaml
+++ b/tests/spread/integration/brotli/task.yaml
@@ -1,0 +1,15 @@
+summary: Integration tests for brotli
+
+execute: |
+
+  # testing for only bins slice
+  rootfs_bins="$(install-slices brotli_bins)"
+
+  # generate a test file
+  echo "Hello World!" > "${rootfs_bins}/input.txt"
+
+  # test compression and decompression commands
+  chroot "${rootfs_bins}" /usr/bin/brotli -k input.txt
+  cmp "${rootfs_bins}/input.txt" <(chroot "${rootfs_bins}" brotli -d -c input.txt.br)
+
+


### PR DESCRIPTION
# Included in this PR:
- A simple slice for testing the changes made in branch `[fix/correct_base_ref](https://github.com/clay-lake/chisel-releases/tree/fix/correct_base_ref)`
See:  https://github.com/canonical/chisel-releases/pull/526