### PR TITLE
feat(25.04): Remove init.d scripts

### DIFF
--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -369,6 +369,3 @@ slices:
   copyright:
     contents:
       /usr/share/doc/apparmor/copyright:
-
-
-

--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -11,13 +11,8 @@ slices:
       - apparmor_config
       - apparmor_profiles
       - libc6_libs
-      # Although lsb-base is not a dependency of apparmor in Oracular, the
-      # /etc/init.d/apparmor script references the /lib/lsb/init-functions.
-      # Thus, lsb-base_bins is listed as an essential here.
-      - lsb-base_bins
     contents:
-      /etc/init.d/apparmor:
-      /sbin/apparmor_parser:
+      /usr/sbin/apparmor_parser:
       /usr/bin/aa-enabled:
       /usr/bin/aa-exec:
       /usr/bin/aa-features-abi:
@@ -34,9 +29,9 @@ slices:
 
   extras:
     contents:
-      /lib/apparmor/apparmor.systemd:
-      /lib/apparmor/profile-load:
-      /lib/apparmor/rc.apparmor.functions:
+      /usr/lib/apparmor/apparmor.systemd:
+      /usr/lib/apparmor/profile-load:
+      /usr/lib/apparmor/rc.apparmor.functions:
       /usr/lib/systemd/system/apparmor.service:
 
   profiles:
@@ -72,6 +67,8 @@ slices:
       /etc/apparmor.d/abstractions/dbus-session-strict:
       /etc/apparmor.d/abstractions/dbus-strict:
       /etc/apparmor.d/abstractions/dconf:
+      /etc/apparmor.d/abstractions/devices-usb:
+      /etc/apparmor.d/abstractions/devices-usb-read:
       /etc/apparmor.d/abstractions/dovecot-common:
       /etc/apparmor.d/abstractions/dri-common:
       /etc/apparmor.d/abstractions/dri-enumerate:
@@ -81,6 +78,8 @@ slices:
       /etc/apparmor.d/abstractions/fcitx-strict:
       /etc/apparmor.d/abstractions/fonts:
       /etc/apparmor.d/abstractions/freedesktop.org:
+      /etc/apparmor.d/abstractions/frr:
+      /etc/apparmor.d/abstractions/frr-snmp:
       /etc/apparmor.d/abstractions/gio-open:
       /etc/apparmor.d/abstractions/gnome:
       /etc/apparmor.d/abstractions/gnupg:
@@ -104,6 +103,7 @@ slices:
       /etc/apparmor.d/abstractions/mozc:
       /etc/apparmor.d/abstractions/mysql:
       /etc/apparmor.d/abstractions/nameservice:
+      /etc/apparmor.d/abstractions/nameservice-strict:
       /etc/apparmor.d/abstractions/nis:
       /etc/apparmor.d/abstractions/nss-systemd:
       /etc/apparmor.d/abstractions/nvidia:
@@ -127,6 +127,9 @@ slices:
       /etc/apparmor.d/abstractions/qt5:
       /etc/apparmor.d/abstractions/qt5-compose-cache-write:
       /etc/apparmor.d/abstractions/qt5-settings-write:
+      /etc/apparmor.d/abstractions/qt6:
+      /etc/apparmor.d/abstractions/qt6-compose-cache-write:
+      /etc/apparmor.d/abstractions/qt6-settings-write:
       /etc/apparmor.d/abstractions/recent-documents-write:
       /etc/apparmor.d/abstractions/ruby:
       /etc/apparmor.d/abstractions/samba:
@@ -136,6 +139,7 @@ slices:
       /etc/apparmor.d/abstractions/ssl_certs:
       /etc/apparmor.d/abstractions/ssl_keys:
       /etc/apparmor.d/abstractions/svn-repositories:
+      /etc/apparmor.d/abstractions/transmission-common:
       /etc/apparmor.d/abstractions/trash:
       /etc/apparmor.d/abstractions/ubuntu-bittorrent-clients:
       /etc/apparmor.d/abstractions/ubuntu-browsers:
@@ -176,35 +180,53 @@ slices:
       /etc/apparmor.d/abstractions/xad:
       /etc/apparmor.d/abstractions/xdg-desktop:
       /etc/apparmor.d/abstractions/xdg-open:
+      /etc/apparmor.d/alsamixer:
+      /etc/apparmor.d/babeld:
+      /etc/apparmor.d/balena-etcher:
+      /etc/apparmor.d/bfdd:
+      /etc/apparmor.d/bgpd:
       /etc/apparmor.d/brave:
       /etc/apparmor.d/buildah:
-      /etc/apparmor.d/busybox:
+      /etc/apparmor.d/bwrap-userns-restrict:
       /etc/apparmor.d/cam:
       /etc/apparmor.d/ch-checkns:
       /etc/apparmor.d/ch-run:
       /etc/apparmor.d/chrome:
+      /etc/apparmor.d/chromium:
       /etc/apparmor.d/code:
       /etc/apparmor.d/crun:
       /etc/apparmor.d/devhelp:
+      /etc/apparmor.d/disable/: {make: true}
+      /etc/apparmor.d/dnstracer:
+      /etc/apparmor.d/eigrpd:
       /etc/apparmor.d/element-desktop:
       /etc/apparmor.d/epiphany:
       /etc/apparmor.d/evolution:
+      /etc/apparmor.d/fabricd:
       /etc/apparmor.d/firefox:
       /etc/apparmor.d/flatpak:
+      /etc/apparmor.d/foliate:
+      /etc/apparmor.d/force-complain/: {make: true}
+      /etc/apparmor.d/fusermount3:
       /etc/apparmor.d/geary:
       /etc/apparmor.d/github-desktop:
       /etc/apparmor.d/goldendict:
+      /etc/apparmor.d/iotop-c:
       /etc/apparmor.d/ipa_verify:
+      /etc/apparmor.d/irssi:
+      /etc/apparmor.d/isisd:
       /etc/apparmor.d/kchmviewer:
       /etc/apparmor.d/keybase:
       /etc/apparmor.d/lc-compliance:
+      /etc/apparmor.d/ldpd:
       /etc/apparmor.d/libcamerify:
+      /etc/apparmor.d/linux-boot-prober:
       /etc/apparmor.d/linux-sandbox:
-      /etc/apparmor.d/local/README:
-      /etc/apparmor.d/local/lsb_release: { text: '' }
-      /etc/apparmor.d/local/nvidia_modprobe: { text: '' }
+      /etc/apparmor.d/local/: {make: true}
       /etc/apparmor.d/loupe:
       /etc/apparmor.d/lsb_release:
+      /etc/apparmor.d/lsblk:
+      /etc/apparmor.d/lsusb:
       /etc/apparmor.d/lxc-attach:
       /etc/apparmor.d/lxc-create:
       /etc/apparmor.d/lxc-destroy:
@@ -212,15 +234,26 @@ slices:
       /etc/apparmor.d/lxc-stop:
       /etc/apparmor.d/lxc-unshare:
       /etc/apparmor.d/lxc-usernsexec:
+      /etc/apparmor.d/mbsync:
       /etc/apparmor.d/mmdebstrap:
+      /etc/apparmor.d/mosquitto:
       /etc/apparmor.d/msedge:
-      /etc/apparmor.d/nautilus:
+      /etc/apparmor.d/nc.openbsd:
+      /etc/apparmor.d/nhrpd:
       /etc/apparmor.d/notepadqq:
       /etc/apparmor.d/nvidia_modprobe:
       /etc/apparmor.d/obsidian:
       /etc/apparmor.d/opam:
+      /etc/apparmor.d/openvpn:
       /etc/apparmor.d/opera:
+      /etc/apparmor.d/os-prober:
+      /etc/apparmor.d/ospf6d:
+      /etc/apparmor.d/ospfd:
       /etc/apparmor.d/pageedit:
+      /etc/apparmor.d/pathd:
+      /etc/apparmor.d/pbrd:
+      /etc/apparmor.d/pim6d:
+      /etc/apparmor.d/pimd:
       /etc/apparmor.d/plasmashell:
       /etc/apparmor.d/podman:
       /etc/apparmor.d/polypane:
@@ -228,10 +261,14 @@ slices:
       /etc/apparmor.d/qcam:
       /etc/apparmor.d/qmapshack:
       /etc/apparmor.d/qutebrowser:
+      /etc/apparmor.d/remmina:
+      /etc/apparmor.d/ripd:
+      /etc/apparmor.d/ripngd:
       /etc/apparmor.d/rootlesskit:
       /etc/apparmor.d/rpm:
       /etc/apparmor.d/rssguard:
       /etc/apparmor.d/runc:
+      /etc/apparmor.d/rygel:
       /etc/apparmor.d/sbuild:
       /etc/apparmor.d/sbuild-abort:
       /etc/apparmor.d/sbuild-adduser:
@@ -250,21 +287,34 @@ slices:
       /etc/apparmor.d/signal-desktop:
       /etc/apparmor.d/slack:
       /etc/apparmor.d/slirp4netns:
+      /etc/apparmor.d/staticd:
       /etc/apparmor.d/steam:
       /etc/apparmor.d/stress-ng:
       /etc/apparmor.d/surfshark:
       /etc/apparmor.d/systemd-coredump:
       /etc/apparmor.d/thunderbird:
+      /etc/apparmor.d/tinyproxy:
+      /etc/apparmor.d/tnftp:
       /etc/apparmor.d/toybox:
+      /etc/apparmor.d/transmission:
       /etc/apparmor.d/trinity:
-      /etc/apparmor.d/tunables/alias:
-      /etc/apparmor.d/tunables/apparmorfs:
-      /etc/apparmor.d/tunables/dovecot:
-      /etc/apparmor.d/tunables/etc:
-      /etc/apparmor.d/tunables/global:
-      /etc/apparmor.d/tunables/home:
-      /etc/apparmor.d/tunables/home.d/site.local:
-      /etc/apparmor.d/tunables/home.d/ubuntu:
+      /etc/apparmor.d/tshark:
+      /etc/apparmor.d/tup:
+      /etc/apparmor.d/tuxedo-control-center:
+      /etc/apparmor.d/unix-chkpwd:
+      /etc/apparmor.d/unprivileged_userns:
+      /etc/apparmor.d/userbindmount:
+      /etc/apparmor.d/uwsgi-core:
+      /etc/apparmor.d/vdens:
+      /etc/apparmor.d/virtiofsd:
+      /etc/apparmor.d/vivaldi-bin:
+      /etc/apparmor.d/vpnns:
+      /etc/apparmor.d/vrrpd:
+      /etc/apparmor.d/wg:
+      /etc/apparmor.d/wg-quick:
+      /etc/apparmor.d/wike:
+      /etc/apparmor.d/wpcom:
+      /etc/apparmor.d/znc:
         text: |
           # This file is auto-generated. It is recommended you update it using:
           # $ sudo dpkg-reconfigure apparmor
@@ -274,6 +324,15 @@ slices:
           # here are appended to @{HOMEDIRS}.  See tunables/home for details.
           #@{HOMEDIRS}+=
         until: mutate
+      /etc/apparmor.d/tunables/alias:
+      /etc/apparmor.d/tunables/apparmorfs:
+      /etc/apparmor.d/tunables/dovecot:
+      /etc/apparmor.d/tunables/etc:
+      /etc/apparmor.d/tunables/global:
+      /etc/apparmor.d/tunables/home:
+      /etc/apparmor.d/tunables/home.d/site.local:
+      /etc/apparmor.d/tunables/rygel:
+      /etc/apparmor.d/tunables/system:
       /etc/apparmor.d/tunables/kernelvars:
       /etc/apparmor.d/tunables/multiarch:
       /etc/apparmor.d/tunables/multiarch.d/site.local:
@@ -305,17 +364,6 @@ slices:
           #@{XDG_PICTURES_DIR}+=""
           #@{XDG_VIDEOS_DIR}+=""
         until: mutate
-      /etc/apparmor.d/tup:
-      /etc/apparmor.d/tuxedo-control-center:
-      /etc/apparmor.d/unix-chkpwd:
-      /etc/apparmor.d/unprivileged_userns:
-      /etc/apparmor.d/userbindmount:
-      /etc/apparmor.d/uwsgi-core:
-      /etc/apparmor.d/vdens:
-      /etc/apparmor.d/virtiofsd:
-      /etc/apparmor.d/vivaldi-bin:
-      /etc/apparmor.d/vpnns:
-      /etc/apparmor.d/wpcom:
       /var/cache/apparmor/:
 
   copyright:

--- a/slices/apparmor.yaml
+++ b/slices/apparmor.yaml
@@ -12,7 +12,6 @@ slices:
       - apparmor_profiles
       - libc6_libs
     contents:
-      /usr/sbin/apparmor_parser:
       /usr/bin/aa-enabled:
       /usr/bin/aa-exec:
       /usr/bin/aa-features-abi:
@@ -20,6 +19,7 @@ slices:
       /usr/sbin/aa-remove-unknown:
       /usr/sbin/aa-status:
       /usr/sbin/aa-teardown:
+      /usr/sbin/apparmor_parser:
       /usr/sbin/apparmor_status:
 
   config:
@@ -37,14 +37,10 @@ slices:
   profiles:
     contents:
       /etc/apparmor.d/1password:
-      /etc/apparmor.d/Discord:
-      /etc/apparmor.d/MongoDB_Compass:
-      /etc/apparmor.d/QtWebEngineProcess:
       /etc/apparmor.d/abi/3.0:
       /etc/apparmor.d/abi/4.0:
       /etc/apparmor.d/abi/kernel-5.4-outoftree-network:
       /etc/apparmor.d/abi/kernel-5.4-vanilla:
-      /etc/apparmor.d/abstractions/X:
       /etc/apparmor.d/abstractions/apache2-common:
       /etc/apparmor.d/abstractions/apparmor_api/change_profile:
       /etc/apparmor.d/abstractions/apparmor_api/examine:
@@ -59,27 +55,27 @@ slices:
       /etc/apparmor.d/abstractions/consoles:
       /etc/apparmor.d/abstractions/crypto:
       /etc/apparmor.d/abstractions/cups-client:
-      /etc/apparmor.d/abstractions/dbus:
-      /etc/apparmor.d/abstractions/dbus-accessibility:
       /etc/apparmor.d/abstractions/dbus-accessibility-strict:
+      /etc/apparmor.d/abstractions/dbus-accessibility:
       /etc/apparmor.d/abstractions/dbus-network-manager-strict:
-      /etc/apparmor.d/abstractions/dbus-session:
       /etc/apparmor.d/abstractions/dbus-session-strict:
+      /etc/apparmor.d/abstractions/dbus-session:
       /etc/apparmor.d/abstractions/dbus-strict:
+      /etc/apparmor.d/abstractions/dbus:
       /etc/apparmor.d/abstractions/dconf:
-      /etc/apparmor.d/abstractions/devices-usb:
       /etc/apparmor.d/abstractions/devices-usb-read:
+      /etc/apparmor.d/abstractions/devices-usb:
       /etc/apparmor.d/abstractions/dovecot-common:
       /etc/apparmor.d/abstractions/dri-common:
       /etc/apparmor.d/abstractions/dri-enumerate:
       /etc/apparmor.d/abstractions/enchant:
       /etc/apparmor.d/abstractions/exo-open:
-      /etc/apparmor.d/abstractions/fcitx:
       /etc/apparmor.d/abstractions/fcitx-strict:
+      /etc/apparmor.d/abstractions/fcitx:
       /etc/apparmor.d/abstractions/fonts:
       /etc/apparmor.d/abstractions/freedesktop.org:
-      /etc/apparmor.d/abstractions/frr:
       /etc/apparmor.d/abstractions/frr-snmp:
+      /etc/apparmor.d/abstractions/frr:
       /etc/apparmor.d/abstractions/gio-open:
       /etc/apparmor.d/abstractions/gnome:
       /etc/apparmor.d/abstractions/gnupg:
@@ -88,11 +84,11 @@ slices:
       /etc/apparmor.d/abstractions/gvfs-open:
       /etc/apparmor.d/abstractions/hosts_access:
       /etc/apparmor.d/abstractions/ibus:
-      /etc/apparmor.d/abstractions/kde:
       /etc/apparmor.d/abstractions/kde-globals-write:
       /etc/apparmor.d/abstractions/kde-icon-cache-write:
       /etc/apparmor.d/abstractions/kde-language-write:
       /etc/apparmor.d/abstractions/kde-open5:
+      /etc/apparmor.d/abstractions/kde:
       /etc/apparmor.d/abstractions/kerberosclient:
       /etc/apparmor.d/abstractions/ldapclient:
       /etc/apparmor.d/abstractions/libpam-systemd:
@@ -102,38 +98,38 @@ slices:
       /etc/apparmor.d/abstractions/mir:
       /etc/apparmor.d/abstractions/mozc:
       /etc/apparmor.d/abstractions/mysql:
-      /etc/apparmor.d/abstractions/nameservice:
       /etc/apparmor.d/abstractions/nameservice-strict:
+      /etc/apparmor.d/abstractions/nameservice:
       /etc/apparmor.d/abstractions/nis:
       /etc/apparmor.d/abstractions/nss-systemd:
       /etc/apparmor.d/abstractions/nvidia:
-      /etc/apparmor.d/abstractions/opencl:
       /etc/apparmor.d/abstractions/opencl-common:
       /etc/apparmor.d/abstractions/opencl-intel:
       /etc/apparmor.d/abstractions/opencl-mesa:
       /etc/apparmor.d/abstractions/opencl-nvidia:
       /etc/apparmor.d/abstractions/opencl-pocl:
+      /etc/apparmor.d/abstractions/opencl:
       /etc/apparmor.d/abstractions/openssl:
       /etc/apparmor.d/abstractions/orbit2:
       /etc/apparmor.d/abstractions/p11-kit:
       /etc/apparmor.d/abstractions/perl:
-      /etc/apparmor.d/abstractions/php:
       /etc/apparmor.d/abstractions/php-worker:
+      /etc/apparmor.d/abstractions/php:
       /etc/apparmor.d/abstractions/php5:
       /etc/apparmor.d/abstractions/postfix-common:
-      /etc/apparmor.d/abstractions/private-files:
       /etc/apparmor.d/abstractions/private-files-strict:
+      /etc/apparmor.d/abstractions/private-files:
       /etc/apparmor.d/abstractions/python:
-      /etc/apparmor.d/abstractions/qt5:
       /etc/apparmor.d/abstractions/qt5-compose-cache-write:
       /etc/apparmor.d/abstractions/qt5-settings-write:
-      /etc/apparmor.d/abstractions/qt6:
+      /etc/apparmor.d/abstractions/qt5:
       /etc/apparmor.d/abstractions/qt6-compose-cache-write:
       /etc/apparmor.d/abstractions/qt6-settings-write:
+      /etc/apparmor.d/abstractions/qt6:
       /etc/apparmor.d/abstractions/recent-documents-write:
       /etc/apparmor.d/abstractions/ruby:
-      /etc/apparmor.d/abstractions/samba:
       /etc/apparmor.d/abstractions/samba-rpcd:
+      /etc/apparmor.d/abstractions/samba:
       /etc/apparmor.d/abstractions/smbpass:
       /etc/apparmor.d/abstractions/snap_browsers:
       /etc/apparmor.d/abstractions/ssl_certs:
@@ -151,8 +147,8 @@ slices:
       /etc/apparmor.d/abstractions/ubuntu-browsers.d/plugins-common:
       /etc/apparmor.d/abstractions/ubuntu-browsers.d/productivity:
       /etc/apparmor.d/abstractions/ubuntu-browsers.d/text-editors:
-      /etc/apparmor.d/abstractions/ubuntu-browsers.d/ubuntu-integration:
       /etc/apparmor.d/abstractions/ubuntu-browsers.d/ubuntu-integration-xul:
+      /etc/apparmor.d/abstractions/ubuntu-browsers.d/ubuntu-integration:
       /etc/apparmor.d/abstractions/ubuntu-browsers.d/user-files:
       /etc/apparmor.d/abstractions/ubuntu-console-browsers:
       /etc/apparmor.d/abstractions/ubuntu-console-email:
@@ -177,6 +173,7 @@ slices:
       /etc/apparmor.d/abstractions/web-data:
       /etc/apparmor.d/abstractions/winbind:
       /etc/apparmor.d/abstractions/wutmp:
+      /etc/apparmor.d/abstractions/X:
       /etc/apparmor.d/abstractions/xad:
       /etc/apparmor.d/abstractions/xdg-desktop:
       /etc/apparmor.d/abstractions/xdg-open:
@@ -197,6 +194,7 @@ slices:
       /etc/apparmor.d/crun:
       /etc/apparmor.d/devhelp:
       /etc/apparmor.d/disable/: {make: true}
+      /etc/apparmor.d/Discord:
       /etc/apparmor.d/dnstracer:
       /etc/apparmor.d/eigrpd:
       /etc/apparmor.d/element-desktop:
@@ -236,6 +234,7 @@ slices:
       /etc/apparmor.d/lxc-usernsexec:
       /etc/apparmor.d/mbsync:
       /etc/apparmor.d/mmdebstrap:
+      /etc/apparmor.d/MongoDB_Compass:
       /etc/apparmor.d/mosquitto:
       /etc/apparmor.d/msedge:
       /etc/apparmor.d/nc.openbsd:
@@ -260,6 +259,7 @@ slices:
       /etc/apparmor.d/privacybrowser:
       /etc/apparmor.d/qcam:
       /etc/apparmor.d/qmapshack:
+      /etc/apparmor.d/QtWebEngineProcess:
       /etc/apparmor.d/qutebrowser:
       /etc/apparmor.d/remmina:
       /etc/apparmor.d/ripd:
@@ -269,7 +269,6 @@ slices:
       /etc/apparmor.d/rssguard:
       /etc/apparmor.d/runc:
       /etc/apparmor.d/rygel:
-      /etc/apparmor.d/sbuild:
       /etc/apparmor.d/sbuild-abort:
       /etc/apparmor.d/sbuild-adduser:
       /etc/apparmor.d/sbuild-apt:
@@ -283,6 +282,7 @@ slices:
       /etc/apparmor.d/sbuild-unhold:
       /etc/apparmor.d/sbuild-update:
       /etc/apparmor.d/sbuild-upgrade:
+      /etc/apparmor.d/sbuild:
       /etc/apparmor.d/scide:
       /etc/apparmor.d/signal-desktop:
       /etc/apparmor.d/slack:
@@ -299,31 +299,6 @@ slices:
       /etc/apparmor.d/transmission:
       /etc/apparmor.d/trinity:
       /etc/apparmor.d/tshark:
-      /etc/apparmor.d/tup:
-      /etc/apparmor.d/tuxedo-control-center:
-      /etc/apparmor.d/unix-chkpwd:
-      /etc/apparmor.d/unprivileged_userns:
-      /etc/apparmor.d/userbindmount:
-      /etc/apparmor.d/uwsgi-core:
-      /etc/apparmor.d/vdens:
-      /etc/apparmor.d/virtiofsd:
-      /etc/apparmor.d/vivaldi-bin:
-      /etc/apparmor.d/vpnns:
-      /etc/apparmor.d/vrrpd:
-      /etc/apparmor.d/wg:
-      /etc/apparmor.d/wg-quick:
-      /etc/apparmor.d/wike:
-      /etc/apparmor.d/wpcom:
-      /etc/apparmor.d/znc:
-        text: |
-          # This file is auto-generated. It is recommended you update it using:
-          # $ sudo dpkg-reconfigure apparmor
-          #
-          # The following is a space-separated list of where additional user home
-          # directories are stored, each must have a trailing '/'. Directories added
-          # here are appended to @{HOMEDIRS}.  See tunables/home for details.
-          #@{HOMEDIRS}+=
-        until: mutate
       /etc/apparmor.d/tunables/alias:
       /etc/apparmor.d/tunables/apparmorfs:
       /etc/apparmor.d/tunables/dovecot:
@@ -331,16 +306,16 @@ slices:
       /etc/apparmor.d/tunables/global:
       /etc/apparmor.d/tunables/home:
       /etc/apparmor.d/tunables/home.d/site.local:
-      /etc/apparmor.d/tunables/rygel:
-      /etc/apparmor.d/tunables/system:
       /etc/apparmor.d/tunables/kernelvars:
       /etc/apparmor.d/tunables/multiarch:
       /etc/apparmor.d/tunables/multiarch.d/site.local:
       /etc/apparmor.d/tunables/proc:
       /etc/apparmor.d/tunables/run:
+      /etc/apparmor.d/tunables/rygel:
       /etc/apparmor.d/tunables/securityfs:
       /etc/apparmor.d/tunables/share:
       /etc/apparmor.d/tunables/sys:
+      /etc/apparmor.d/tunables/system:
       /etc/apparmor.d/tunables/xdg-user-dirs:
       /etc/apparmor.d/tunables/xdg-user-dirs.d/site.local:
         text: |
@@ -364,8 +339,36 @@ slices:
           #@{XDG_PICTURES_DIR}+=""
           #@{XDG_VIDEOS_DIR}+=""
         until: mutate
+      /etc/apparmor.d/tup:
+      /etc/apparmor.d/tuxedo-control-center:
+      /etc/apparmor.d/unix-chkpwd:
+      /etc/apparmor.d/unprivileged_userns:
+      /etc/apparmor.d/userbindmount:
+      /etc/apparmor.d/uwsgi-core:
+      /etc/apparmor.d/vdens:
+      /etc/apparmor.d/virtiofsd:
+      /etc/apparmor.d/vivaldi-bin:
+      /etc/apparmor.d/vpnns:
+      /etc/apparmor.d/vrrpd:
+      /etc/apparmor.d/wg-quick:
+      /etc/apparmor.d/wg:
+      /etc/apparmor.d/wike:
+      /etc/apparmor.d/wpcom:
+      /etc/apparmor.d/znc:
+        text: |
+          # This file is auto-generated. It is recommended you update it using:
+          # $ sudo dpkg-reconfigure apparmor
+          #
+          # The following is a space-separated list of where additional user home
+          # directories are stored, each must have a trailing '/'. Directories added
+          # here are appended to @{HOMEDIRS}.  See tunables/home for details.
+          #@{HOMEDIRS}+=
+        until: mutate
       /var/cache/apparmor/:
 
   copyright:
     contents:
       /usr/share/doc/apparmor/copyright:
+
+
+

--- a/slices/dbus.yaml
+++ b/slices/dbus.yaml
@@ -9,18 +9,12 @@ slices:
       - dbus-bin_bins
       - dbus-daemon_bins
       - dbus-system-bus-common_config
-      - dbus_config
       - libc6_libs
       - libdbus-1-3_libs
       - libexpat1_libs
       - libsystemd0_libs
     contents:
-      /etc/init.d/dbus:
       /usr/lib/dbus-*/dbus-daemon-launch-helper:
-
-  config:
-    contents:
-      /etc/default/dbus:
 
   services:
     essential:

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -9,13 +9,13 @@ slices:
       - libc6_libs
       - libzstd1_libs
       - zlib1g_libs
+      - openssl-provider-legacy_libs
     contents:
       /usr/lib/*-linux-*/engines-3/afalg.so:
       /usr/lib/*-linux-*/engines-3/loader_attic.so:
-      /usr/lib/*-linux-*/engines-3/padlock.so:
+      # /usr/lib/*-linux-*/engines-3/padlock.so: # only available on arm64 and i386
       /usr/lib/*-linux-*/libcrypto.so.*:
       /usr/lib/*-linux-*/libssl.so.*:
-      /usr/lib/*-linux-*/ossl-modules/legacy.so:
 
   copyright:
     contents:

--- a/slices/libssl3t64.yaml
+++ b/slices/libssl3t64.yaml
@@ -8,8 +8,8 @@ slices:
     essential:
       - libc6_libs
       - libzstd1_libs
-      - zlib1g_libs
       - openssl-provider-legacy_libs
+      - zlib1g_libs
     contents:
       /usr/lib/*-linux-*/engines-3/afalg.so:
       /usr/lib/*-linux-*/engines-3/loader_attic.so:

--- a/slices/nginx-common.yaml
+++ b/slices/nginx-common.yaml
@@ -10,7 +10,6 @@ slices:
   # There's also no need (yet) for any init- and systemd-related files.
   config:
     contents:
-      /etc/logrotate.d/nginx:
       /etc/nginx/fastcgi.conf:
       /etc/nginx/fastcgi_params:
       /etc/nginx/koi-utf:

--- a/slices/openssh-server.yaml
+++ b/slices/openssh-server.yaml
@@ -6,7 +6,7 @@ slices:
     # a user during package install/removal - however we don't support this
     # currently so adduser is not added here.
     essential:
-      - init-system-helpers_bins
+      - dash_bins
       - libaudit1_libs
       - libc6_libs
       - libcom-err2_libs
@@ -19,20 +19,16 @@ slices:
       - libselinux1_libs
       - libssl3t64_libs
       - libwrap0_libs
-      - lsb-base_bins
       - openssh-client_bins
       - openssh-sftp-server_bins
       - procps_bins
-      - ucf_bins
       - zlib1g_libs
     contents:
-      /etc/init.d/ssh:
       /usr/lib/openssh/ssh-session-cleanup:
       /usr/sbin/sshd:
 
   config:
     contents:
-      /etc/default/ssh:
       /etc/pam.d/sshd:
       /etc/ssh/moduli:
       /etc/ssh/sshd_config.d/:
@@ -41,6 +37,8 @@ slices:
       /usr/share/openssh/sshd_config.md5sum:
 
   services:
+    essential:
+      - init-system-helpers_bins
     contents:
       /usr/lib/systemd/system/rescue-ssh.target:
       /usr/lib/systemd/system/ssh.service:

--- a/slices/openssl-provider-legacy.yaml
+++ b/slices/openssl-provider-legacy.yaml
@@ -1,0 +1,16 @@
+package: openssl-provider-legacy
+
+essential:
+  - openssl-provider-legacy_copyright
+
+slices:
+  libs:
+    essential:
+      - libc6_libs
+      # - libssl3t64_libs # prevent circular dependency with libssl3t64
+    contents:
+      /usr/lib/*-linux-*/ossl-modules/legacy.so:
+
+  copyright:
+    contents:
+      /usr/share/doc/openssl-provider-legacy/copyright:


### PR DESCRIPTION
# Included in this PR:
- Removal of init.d scripts from SDFs. https://github.com/canonical/chisel-releases/pull/426#discussion_r1881749503
- Removal of `/etc/default/*` scripts from SDFs. See https://github.com/canonical/chisel-releases/pull/426#discussion_r1882148623
- Removal of `/etc/logrotate.d/*` scripts from SDFs. See https://github.com/canonical/chisel-releases/pull/426#discussion_r1882159714

See https://github.com/canonical/chisel-releases/issues/429