### PR TITLE
Feat(25.04): Reconfigure openssl

### DIFF
--- a/slices/openssl.yaml
+++ b/slices/openssl.yaml
@@ -17,17 +17,19 @@ slices:
 
   config:
     contents:
-      /etc/ssl/certs/:
       /etc/ssl/openssl.cnf:
-      /etc/ssl/private/:
-      /usr/lib/ssl/certs:
       /usr/lib/ssl/openssl.cnf:
-      /usr/lib/ssl/private:
 
   data:
     contents:
+      /etc/ssl/certs/:
+      /etc/ssl/private/:
       /usr/lib/ssl/cert.pem:
+      /usr/lib/ssl/certs:
+      /usr/lib/ssl/private:
 
   copyright:
+    essential:
+      - libssl3t64_copyright
     contents:
       /usr/share/doc/openssl/copyright:


### PR DESCRIPTION
# Included in this PR
- Reconfigure openssl to relocate certain config content to data
- Add missing copyright essentials